### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -96,7 +96,7 @@ RUN cd icu/source && ./configure --prefix=/usr --enable-static --disable-shared 
 ENV PHANTOMJS_TAG=master
 RUN apt-get install -y git
 #RUN git clone https://github.com/ariya/phantomjs.git
-RUN git clone https://github.com/bprodoehl/phantomjs.git
+COPY . phantomjs
 
 CMD cd phantomjs && git checkout ${PHANTOMJS_TAG} && ./build.sh --confirm && cp bin/phantomjs /output/.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,8 @@ RUN curl -sL http://downloads.webmproject.org/releases/webp/libwebp-${LIBWEBP_VE
 RUN cd libwebp-${LIBWEBP_VER} && ./configure --prefix=/usr --enable-static --disable-shared && make all -j${NUM_CORES} && make install
 
 # OpenSSL
-ENV OPENSSL_VER=1.0.2d
-RUN curl -sL http://openssl.org/source/openssl-${OPENSSL_VER}.tar.gz | tar -xz
+ENV OPENSSL_VER=1.0.2e
+RUN curl -sL https://openssl.org/source/openssl-${OPENSSL_VER}.tar.gz | tar -xz
 RUN cd openssl-${OPENSSL_VER} && ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib && make all && make install
 
 RUN apt-get install -y pkg-config

--- a/Dockerfile
+++ b/Dockerfile
@@ -98,5 +98,5 @@ RUN apt-get install -y git
 #RUN git clone https://github.com/ariya/phantomjs.git
 COPY . phantomjs
 
-CMD cd phantomjs && git checkout ${PHANTOMJS_TAG} && ./build.sh --confirm && cp bin/phantomjs /output/.
-
+RUN cd phantomjs && git checkout ${PHANTOMJS_TAG} && ./build.sh --confirm
+CMD cp phantomjs/bin/phantomjs /output/.

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -56,7 +56,7 @@ RUN curl -sL http://downloads.webmproject.org/releases/webp/libwebp-${LIBWEBP_VE
 RUN cd libwebp-${LIBWEBP_VER} && ./configure --prefix=/usr --enable-static --disable-shared && make all -j${NUM_CORES} && make install
 
 # OpenSSL
-ENV OPENSSL_VER=1.0.2a
+ENV OPENSSL_VER=1.0.2d
 RUN curl -sL http://openssl.org/source/openssl-${OPENSSL_VER}.tar.gz | tar -xz
 RUN cd openssl-${OPENSSL_VER} && ./config --prefix=/usr --openssldir=/etc/ssl --libdir=lib && make all && make install
 


### PR DESCRIPTION
I fixed the Docker build and changed the Dockerfile so it uses the code from current checkout instead of cloning the current master branch from Github. Also, as I do not see any advantage in compiling the project during run, the project is already compiled during the image build. 

This makes it easy to set up [automated builds](https://docs.docker.com/docker-hub/builds/) on the Docker registry hub. You can even set up builds for different branches easily using this technique. @bprodoehl, it would be useful if you could set up such an automated build for this fork so others can easily get the latest binary (and your upcoming 2.1 work?). 

In the long run, it would probably make sense for PhantomJS to use Docker and do static Docker builds for their regular releases. This is one of the use cases where Docker really shines.
